### PR TITLE
make `$safe` variable argument

### DIFF
--- a/src/Collector/EncountCollector.php
+++ b/src/Collector/EncountCollector.php
@@ -90,9 +90,8 @@ class EncountCollector
      * @access public
      * @author sakuragawa
      */
-    public function ip()
+    public function ip($safe=true)
     {
-        $safe = true;
         if (!$safe && env('HTTP_X_FORWARDED_FOR')) {
             $env = 'HTTP_X_FORWARDED_FOR';
             $ipaddr = preg_replace('/(?:,.*)/', '', env('HTTP_X_FORWARDED_FOR'));


### PR DESCRIPTION
`if block` in L.96 seems not to be working. It is because `$safe` variable is settled as `true` before the `if block`.
When move `$safe` to the function arguments, user can handle the `$safe` variable, and the `if block` will work!

In this PR,  the variable `$safe` moved to the function argument.