### PR TITLE
Bug fix

### DIFF
--- a/src/Collector/EncountCollector.php
+++ b/src/Collector/EncountCollector.php
@@ -67,11 +67,10 @@ class EncountCollector
         $this->environment = $_SERVER;
         $this->cookie = $_COOKIE;
 
+        $this->requestParams = [];
         $request = Router::getRequest();
         if (!is_null($request)) {
             $this->requestParams = $request->getAttributes();
-        } else {
-            $this->requestParams = null;
         }
     }
 

--- a/src/Collector/EncountCollector.php
+++ b/src/Collector/EncountCollector.php
@@ -63,10 +63,16 @@ class EncountCollector
         $this->url = $this->url();
         $this->ip = $this->ip();
         $this->referer = env('HTTP_REFERER');
-        $this->requestParams = Router::getRequest()->getAttributes();
         $this->session = isset($_SESSION) ? $_SESSION : array();
         $this->environment = $_SERVER;
         $this->cookie = $_COOKIE;
+
+        $request = Router::getRequest();
+        if (!is_null($request)) {
+            $this->requestParams = $request->getAttributes();
+        } else {
+            $this->requestParams = null;
+        }
     }
 
     /**


### PR DESCRIPTION
if this plugin is called in middleware, the request is not set yet, and it strikes an fatal error.  
By this modification, null will be settled if Router::getRequest() is null.